### PR TITLE
Replace nginx image and expose it outside of the cluster

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+RUN apk add --update --no-cache bash inotify-tools nginx curl openssl tcpdump
+RUN sed -i 's?^#include /etc/nginx/conf.d/\*\.conf;?include /etc/nginx/conf.d/*.conf;?' /etc/nginx/nginx.conf
+RUN sed -i '/http {/,$d' /etc/nginx/nginx.conf
+CMD ["nginx", "-g", "daemon off;"]

--- a/deployment/nginx-server.yml
+++ b/deployment/nginx-server.yml
@@ -4,30 +4,30 @@ metadata:
   name: nginx-config
 data:
   default.conf: |-
-    access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log debug;
-    server {
-        listen 80;
-        server_name nginx.cert-manager.svc.cluster.local;
-        return 301 https://nginx$request_uri;
-    }
-    server {
-        listen 443 ssl;
-        root /usr/share/nginx/html;
-        index index.html;
+    http {
+        server {
+            listen 80;
+            server_name nginx;
+            return 301 https://nginx$request_uri;
+        }
+        server {
+            listen 443 ssl;
+            root /var/lib/nginx/html;
+            index index.html;
 
-        server_name nginx.cert-manager.svc.cluster.local;
-        ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_certificate /etc/nginx/ssl/tls.crt;
-        ssl_certificate_key /etc/nginx/ssl/tls.key;
-        ssl_client_certificate /etc/nginx/ssl/ca.crt;
-        ssl_verify_client optional;
+            server_name nginx;
+            ssl_protocols TLSv1.2 TLSv1.3;
+            ssl_certificate /etc/nginx/ssl/tls.crt;
+            ssl_certificate_key /etc/nginx/ssl/tls.key;
+            #ssl_client_certificate /etc/nginx/ssl/ca.crt;
+            #ssl_verify_client optional;
 
-        location / {
-            if ($ssl_client_verify != SUCCESS) {
-              return 403;
-            }
-            try_files $uri $uri/ =404;
+            #location / {
+            #    if ($ssl_client_verify != SUCCESS) {
+            #      return 403;
+            #    }
+            #    try_files $uri $uri/ =404;
+            #}
         }
     }
 ---
@@ -38,6 +38,7 @@ metadata:
   labels:
     app: nginx
 spec:
+  type: ClusterIP
   ports:
   - port: 80
     protocol: TCP
@@ -46,6 +47,26 @@ spec:
     protocol: TCP
     name: https
   - port: 81
+    protocol: TCP
+    name: tls-test
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-external
+  labels:
+    app: nginx
+spec:
+  type: NodePort
+  ports:
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: https
+  - port: 81
+    targetPort: 81
     protocol: TCP
     name: tls-test
   selector:
@@ -74,30 +95,13 @@ spec:
         configMap:
           name: nginx-config
       containers:
-      - name: nginx-https
-        image: nginx
-        command: [ "sh", "-c", "nginx -g 'daemon off;'" ]
+      - name: nginx
+        image: localrepo/alpine-nginx
+        imagePullPolicy: Never
+        command: ["sh", "-c", "while true; do inotifywait -e delete_self /etc/nginx/ssl/tls.crt && echo \"$(date): cert changed\" && nginx -s reload; done & nginx -g 'daemon off;'"]
         ports:
         - containerPort: 443
         - containerPort: 80
-        volumeMounts:
-        - mountPath: /etc/nginx/ssl
-          name: secret-volume
-        - mountPath: /etc/nginx/conf.d
-          name: configmap-volume
-      - name: alpine
-        image: alpine
-        lifecycle:
-          postStart:
-            exec:
-              command:
-                [
-                  "sh",
-                  "-c",
-                  "apk add --update --no-cache bash curl openssl tcpdump"
-                ]
-        command: ["sh", "-c", "trap : TERM INT; sleep infinity & wait"]
-        ports:
         - containerPort: 81
         volumeMounts:
         - mountPath: /etc/nginx/ssl

--- a/deployment/server-certificate.yml
+++ b/deployment/server-certificate.yml
@@ -12,8 +12,8 @@ spec:
     labels:
       my-secret-label: foo
 
-  duration: 2160h # 90d
-  renewBefore: 360h # 15d
+  duration: 2m # 90d
+  renewBefore: 90s # 15d
   subject:
     organizations:
       - example
@@ -36,8 +36,8 @@ spec:
     - nginx.cert-manager.svc.cluster.local
   #uris:
   #  - spiffe://cluster.local/ns/sandbox/sa/example
-  #ipAddresses:
-  #  - 192.168.0.5
+  ipAddresses:
+    - 127.0.0.1
   # Issuer references are always required.
   issuerRef:
     name: vault-issuer


### PR DESCRIPTION
Add custom alpine Docker image with nginx.
Add inotifywait inside it to restart nginx service at certificate renewal.
Add NodePort service for nginx.
Decrease the nginx server's certificate duration time to 2 minutes.